### PR TITLE
fix: use absolute links instead of relative

### DIFF
--- a/our-work/apps/index.yml
+++ b/our-work/apps/index.yml
@@ -6,4 +6,4 @@ fa:
   icon: browser
 links:
   - text: go to web applications
-    target: our-work/apps
+    target: /our-work/apps

--- a/our-work/software/index.yml
+++ b/our-work/software/index.yml
@@ -6,4 +6,4 @@ fa:
   icon: code-merge
 links:
   - text: go to software
-    target: our-work/software
+    target: /our-work/software

--- a/our-work/talks/index.yml
+++ b/our-work/talks/index.yml
@@ -6,4 +6,4 @@ fa:
   icon: presentation
 links:
   - text: go to talks
-    target: our-work/talks
+    target: /our-work/talks

--- a/our-work/workshops/index.yml
+++ b/our-work/workshops/index.yml
@@ -6,4 +6,4 @@ fa:
   icon: user-chart
 links:
   - text: go to workshops
-    target: our-work/workshops
+    target: /our-work/workshops

--- a/services/classroom/index.yml
+++ b/services/classroom/index.yml
@@ -1,13 +1,13 @@
 title: Classroom
 description: |
-  CCV services to help prefessors in the classroom. 
+  CCV services to help prefessors in the classroom.
   We can provide tutorials or give you access to cutting edge technology for teaching with code, such as JupyterHub.
 fa:
   prefix: fas
   icon: users-class
 links:
   - text: See all classroom services
-    target: services/classroom
+    target: /services/classroom
   - text: Jupyterhub documentation
     target: https://docs.ccv.brown.edu/jupyterhub
 hidden: false

--- a/services/computing/index.yml
+++ b/services/computing/index.yml
@@ -6,7 +6,7 @@ fa:
   icon: server
 links:
   - text: See all computing services
-    target: services/computing
+    target: /services/computing
   - text: Oscar documentation
     target: https://docs.ccv.brown.edu/oscar
   - text: Stronghold documentation

--- a/services/consulting/index.yml
+++ b/services/consulting/index.yml
@@ -1,9 +1,9 @@
 title: Advanced Research Computing - Consulting
 description: |
-  We provide support for researchers seeking help with statistical modeling, machine learning, data mining, data visualization, computational biology, high-performance computing, and software engineering. 
+  We provide support for researchers seeking help with statistical modeling, machine learning, data mining, data visualization, computational biology, high-performance computing, and software engineering.
 fa:
   prefix: fas
   icon: user-ninja
 links:
   - text: Learn more about our consulting services
-    target: services/consulting/advanced-research-computing
+    target: /services/consulting/advanced-research-computing

--- a/services/file-storage-and-transfer/index.yml
+++ b/services/file-storage-and-transfer/index.yml
@@ -1,42 +1,42 @@
 title: File storage and transfer
 description: |
-  Several services at Brown allow you to share and store files. This guide will let you compare the options and decide which one(s) are right for you. 
+  Several services at Brown allow you to share and store files. This guide will let you compare the options and decide which one(s) are right for you.
 fa:
   prefix: fas
   icon: database
 links:
   - text: check our storage options
-    target: services/file-storage-and-transfer
+    target: /services/file-storage-and-transfer
 
 storage_tool_header: |
-  This tool lets you compare the available storage options at Brown. 
+  This tool lets you compare the available storage options at Brown.
   Answer some of these questions or select services to compare their features
   and decide which of these services suit your needs.
 
 services:
   - service: "Google Drive"
     description: |
-      Google Drive gives you unlimited space to store and share documents. 
-      The native Google document formats allow for real-time collaboration and file history. 
-      You can also store unconverted files of various types in your Google Drive. 
-      It's easy to share files with members of the Brown community (including Google Groups) 
-      and non-Brown Google accounts; files can be shared with view-only, comment, or edit access. 
-      Google also has a really nice feature where you can scan in handwritten documents and have 
-      them converted to text. You can access files on the web, through a mobile app, or by 
-      installing Google Drive on your computer (which makes it act like a folder on your 
+      Google Drive gives you unlimited space to store and share documents.
+      The native Google document formats allow for real-time collaboration and file history.
+      You can also store unconverted files of various types in your Google Drive.
+      It's easy to share files with members of the Brown community (including Google Groups)
+      and non-Brown Google accounts; files can be shared with view-only, comment, or edit access.
+      Google also has a really nice feature where you can scan in handwritten documents and have
+      them converted to text. You can access files on the web, through a mobile app, or by
+      installing Google Drive on your computer (which makes it act like a folder on your
       computer).
       - Best for: Collaboration in native Google files, easy access from anywhere, unlimited storage, sharing with Google Groups.
-      - Limitations: Data transfer speeds may be limited when uploading/downloading large amounts of data, Globus can provide high bandwidth data transfers. 
+      - Limitations: Data transfer speeds may be limited when uploading/downloading large amounts of data, Globus can provide high bandwidth data transfers.
       - Rate: Free
       - More info: [Service Catalog](https://it.brown.edu/services/type/google-drive) | [Documentation](https://ithelp.brown.edu/kb/48-google-drive) | [Redundancy](https://storage.googleapis.com/gfw-touched-accounts-pdfs/google-cloud-security-and-compliance-whitepaper.pdf)
-      
+
     features:
       - name: relative_speed
         class: fast
         notes:
       - name: collaborative_edits
         class: true
-        notes: 
+        notes:
       - name: shareable_link
         class: true
         notes:
@@ -44,8 +44,8 @@ services:
         class: false
         notes:
       - name: data_protection
-        class: true 
-        notes: 
+        class: true
+        notes:
           - up to 60 days
       - name: canvas_integration
         class: false
@@ -57,17 +57,17 @@ services:
         class: false
         notes:
       - name: access_from_oscar
-        class: partial 
-        notes: 
+        class: partial
+        notes:
           - accessible via API
       - name: security
         class: 2
-        notes: 
+        notes:
           - prevent editors from resharing
           - set expiration date
       - name: storage
         class: unlimited
-        notes: 
+        notes:
           - per user
       - name: max_file_size
         class: 5 TB
@@ -75,15 +75,15 @@ services:
 
   - service: campus_file_storage_non-replicated
     description: |
-      File Services for Research provides Brown University research departments with a 
-      location in which files can be stored, backed up, and shared with members of the 
-      Brown community using Brown ID’s and groups.  Space is allocated to each research 
-      lab or PI with an ITHelp request , security groups are required to define access 
-      to the data.   The data is accessible on Brown's campus networks (including VPN and 
+      File Services for Research provides Brown University research departments with a
+      location in which files can be stored, backed up, and shared with members of the
+      Brown community using Brown ID’s and groups.  Space is allocated to each research
+      lab or PI with an ITHelp request , security groups are required to define access
+      to the data.   The data is accessible on Brown's campus networks (including VPN and
       wireless).
       - Synonyms: LRS.Brown.EDU, LRSFiles, Qumulo
-      - Best for:  Brown faculty and staff researchers looking to store, share and protect research data. 
-      - Limitations: Not intended for high throughput research computing, you can access this storage on the transfer nodes and utilize HPC scratch for accelerated computing.  
+      - Best for:  Brown faculty and staff researchers looking to store, share and protect research data.
+      - Limitations: Not intended for high throughput research computing, you can access this storage on the transfer nodes and utilize HPC scratch for accelerated computing.
       - Rate: $50/TB/Year when storing above free/grant allocations
       - More info: [Documentation](https://docs.google.com/document/d/1IUBLNqXDnCZk1d4A3RlG823IxKTKiWlVc618vTjI170/edit?usp=sharing) | [Replication](https://ithelp.brown.edu/kb/articles/decide-how-to-store-and-share-files-for-researchers#replication) | [Request this service ](https://brown.co1.qualtrics.com/jfe/form/SV_a5DbCjYNMb5iU0B)
     features:
@@ -92,7 +92,7 @@ services:
         notes:
       - name: collaborative_edits
         class: false
-        notes: 
+        notes:
       - name: shareable_link
         class: true
         notes:
@@ -101,8 +101,8 @@ services:
         class: false
         notes:
       - name: data_protection
-        class: true 
-        notes: 
+        class: true
+        notes:
           - up to 60 days
       - name: canvas_integration
         class: false
@@ -115,16 +115,16 @@ services:
         notes:
           - except with Globus
       - name: access_from_oscar
-        class: partial 
-        notes: 
+        class: partial
+        notes:
           - accessible on transfer nodes
       - name: security
         class: 2
-        notes: 
+        notes:
           - Access controlled by Brown Authentication and Security groups
       - name: storage
         class: 2 TB +
-        notes: 
+        notes:
           - 2 TB per PI
           - 20 TB per grant
           - Paid after that @ $50/TB/Yr. (Consolidated across all paid storage types.)
@@ -135,17 +135,17 @@ services:
 
   - service: campus_file_storage_replicated
     description: |
-      File Services for Research provides Brown University research departments with a 
-      location in which files can be stored, backed up, and shared with members of the 
-      Brown community using Brown ID’s and groups.  Space is allocated to each research 
-      lab or PI with an ITHelp request , security groups are required to define access to 
-      the data.  The data is replicated daily to our disaster recovery site for true 
-      geo-redundant data protection.  The data is accessible on Brown's campus networks 
+      File Services for Research provides Brown University research departments with a
+      location in which files can be stored, backed up, and shared with members of the
+      Brown community using Brown ID’s and groups.  Space is allocated to each research
+      lab or PI with an ITHelp request , security groups are required to define access to
+      the data.  The data is replicated daily to our disaster recovery site for true
+      geo-redundant data protection.  The data is accessible on Brown's campus networks
       (including VPN and wireless).
       - Synonyms: Files.Brown.EDU, Files, Isilon
-      - Best for:  Brown faculty and staff researchers looking to store, share and protect research data. 
+      - Best for:  Brown faculty and staff researchers looking to store, share and protect research data.
       - Limitations:  Not intended for high throughput research computing, you can access this storage on the transfer nodes and utilize HPC scratch for accelerated computing.
-      - Rate: $100/TB/Year when storing above free/grant allocations   
+      - Rate: $100/TB/Year when storing above free/grant allocations
       - More info: [Documentation](https://docs.google.com/document/d/1GiUyKqo6sk9c00tOAkR3Q_GBlBhGs2Ob8EO6pYneNDc/edit?usp=sharing) | [Replication](https://ithelp.brown.edu/kb/articles/decide-how-to-store-and-share-files-for-researchers#replication) | [Request this service](https://brown.co1.qualtrics.com/jfe/form/SV_a5DbCjYNMb5iU0B)
     features:
       - name: relative_speed
@@ -153,7 +153,7 @@ services:
         notes:
       - name: collaborative_edits
         class: false
-        notes: 
+        notes:
       - name: shareable_link
         class: true
         notes:
@@ -162,8 +162,8 @@ services:
         class: false
         notes:
       - name: data_protection
-        class: true 
-        notes: 
+        class: true
+        notes:
           - up to 60 days
       - name: canvas_integration
         class: false
@@ -176,16 +176,16 @@ services:
         notes:
           - except with Globus
       - name: access_from_oscar
-        class: partial 
-        notes: 
+        class: partial
+        notes:
           - accessible on transfer nodes
       - name: security
         class: 2
-        notes: 
+        notes:
           - Access controlled by Brown Authentication and Security groups
       - name: storage
         class: 1 TB +
-        notes: 
+        notes:
           - 1 TB per PI
           - 10 TB per grant
           - Paid after that @ $100/TB/Yr. (Consolidated across all paid storage types.)
@@ -196,11 +196,11 @@ services:
 
   - service: Brown_Digital_Repository
     description: |
-      The Brown Digital Repository (BDR) is a place to gather, index, store, preserve, and make 
-      available digital assets produced via the scholarly, instructional, research, and administrative 
+      The Brown Digital Repository (BDR) is a place to gather, index, store, preserve, and make
+      available digital assets produced via the scholarly, instructional, research, and administrative
       activities at Brown.
 
-      The Brown University Library maintains the repository as a service to the Brown community; it 
+      The Brown University Library maintains the repository as a service to the Brown community; it
       provides:
 
       - A searchable index of digital objects shared by the Brown community.
@@ -209,8 +209,8 @@ services:
       - Tools for sharing and publishing digital content.
       - Data curation, format migration, and preservation services.
 
-      Faculty and researchers interested in using the Brown Digital Repository as a platform for 
-      programmatic data management, storage, and publication should contact the Library (bdr@brown.edu) 
+      Faculty and researchers interested in using the Brown Digital Repository as a platform for
+      programmatic data management, storage, and publication should contact the Library (bdr@brown.edu)
       for information about opportunities for research consulting and project development support.
       - More info: [Documentation](https://repository.library.brown.edu/studio/about/)
     features:
@@ -219,7 +219,7 @@ services:
         notes:
       - name: collaborative_edits
         class: false
-        notes: 
+        notes:
       - name: shareable_link
         class: true
         notes:
@@ -227,8 +227,8 @@ services:
         class: true
         notes:
       - name: data_protection
-        class: true 
-        notes: 
+        class: true
+        notes:
           - up to 60 days
       - name: canvas_integration
         class: false
@@ -241,16 +241,16 @@ services:
         notes:
           - except with Globus
       - name: access_from_oscar
-        class: partial 
-        notes: 
+        class: partial
+        notes:
           - accessible on transfer nodes
       - name: security
         class: 2
-        notes: 
+        notes:
           - Access controlled by Brown Authentication and Security groups
       - name: storage
         class: 1 TB +
-        notes: 
+        notes:
       - name: max_file_size
         class: 4 GB
         notes:
@@ -258,9 +258,9 @@ services:
 
   - service: LabArchives
     description: |
-      LabArchives is a cloud-based electronic lab notebook that can be used by researchers, instructors, and 
-      students for input and organization of laboratory data, information sharing, and collaboration, and for 
-      saving historical versions of files. It is appropriate for use in a wide variety of laboratories, including 
+      LabArchives is a cloud-based electronic lab notebook that can be used by researchers, instructors, and
+      students for input and organization of laboratory data, information sharing, and collaboration, and for
+      saving historical versions of files. It is appropriate for use in a wide variety of laboratories, including
       biological sciences, chemistry and physical sciences, and engineering, among others.
 
       LabArchives at Brown provides unlimited storage space. The current size limit per file is 4GB.
@@ -274,7 +274,7 @@ services:
         notes:
       - name: collaborative_edits
         class: true
-        notes: 
+        notes:
       - name: shareable_link
         class: true
         notes:
@@ -282,8 +282,8 @@ services:
         class: false
         notes:
       - name: data_protection
-        class: true 
-        notes: 
+        class: true
+        notes:
           - up to 60 days
       - name: canvas_integration
         class: true
@@ -296,25 +296,25 @@ services:
         notes:
           - except with Globus
       - name: access_from_oscar
-        class: partial 
-        notes: 
+        class: partial
+        notes:
           - accessible on transfer nodes
       - name: security
         class: 2
-        notes: 
+        notes:
           - Access controlled by Brown Authentication and Security groups
       - name: storage
         class: 1 TB +
-        notes: 
+        notes:
       - name: max_file_size
         class: 4 GB
         notes:
 
   - service: research_data_storage
-    description: | 
+    description: |
       RData is a high-performance data storage system which is accessible from any computer connected from Brown's campus network, or from outside the network via ssh.  It is backed up nightly on an incremental basis. What sets this option apart from the others is that it is directly connected to Brown’s primary supercomputer, “Oscar”, making computation easier. If you don’t intend to compute your data with Brown’s supercomputer, you may consider using Campus File Storage / Research instead. You could also use RData for computing and then move your results to Campus File Storage for greater accessibility, reliability, and protection.
 
-      - Synonyms: RDATA, GPFS, HPC Storage, Oscar Storage 
+      - Synonyms: RDATA, GPFS, HPC Storage, Oscar Storage
       - Best for: High performance storage of research data, perform computation on your data using Brown’s supercomputer
       - Limitations: Not accessible on all campus networks.
       - Rate: $100/TB/Year when storing above free/grant allocations
@@ -325,7 +325,7 @@ services:
         notes:
       - name: collaborative_edits
         class: false
-        notes: 
+        notes:
       - name: shareable_link
         class: true
         notes:
@@ -334,8 +334,8 @@ services:
         class: false
         notes:
       - name: data_protection
-        class: true 
-        notes: 
+        class: true
+        notes:
           - daily snapshots with 7 days retention
       - name: canvas_integration
         class: false
@@ -348,27 +348,27 @@ services:
         notes:
           - except with Globus
       - name: access_from_oscar
-        class: partial 
-        notes: 
+        class: partial
+        notes:
           - accessible on transfer nodes
       - name: security
         class: 2
-        notes: 
+        notes:
           - Access controlled by Brown Authentication and Security groups
       - name: storage
         class: 1 TB +
-        notes: 
+        notes:
           - 1 TB per PI
           - 10 TB per grant
           - Paid after that @ $100/TB/Yr. (Consolidated across all paid storage types.)
       - name: max_file_size
         class: 8 XB
         notes:
-    
+
   - service: stronghold
     description: |
-      Stronghold is a secure computing and storage environment that enables 
-      Brown researchers to analyze sensitive data while complying with regulatory 
+      Stronghold is a secure computing and storage environment that enables
+      Brown researchers to analyze sensitive data while complying with regulatory
       or contractual requirements.
       - Best for: Storing data with data usage agreements, FISMA, etc.
       - Rate: $100/TB/Year when storing above free/grant allocations
@@ -379,7 +379,7 @@ services:
         notes:
       - name: collaborative_edits
         class: false
-        notes: 
+        notes:
       - name: shareable_link
         class: false
         notes:
@@ -387,8 +387,8 @@ services:
         class: false
         notes:
       - name: data_protection
-        class: true 
-        notes: 
+        class: true
+        notes:
           - up to 6 weeks
       - name: canvas_integration
         class: false
@@ -401,15 +401,15 @@ services:
         notes:
           - except with Globus
       - name: access_from_oscar
-        class: false 
-        notes: 
+        class: false
+        notes:
       - name: security
         class: 3
         notes:
           - Appropriate for data with strong data compliance requirements PII, HIPAA, etc
       - name: storage
         class: 1 TB +
-        notes: 
+        notes:
           - 1 TB per PI
           - 10 TB per grant
           - Paid after that @ $100/TB/Yr. (Consolidated across all paid storage types.)
@@ -420,17 +420,17 @@ services:
 questions:
   - question: What is the risk classification of your data?
     information: |
-      Brown has classified its information assets into one of four risk-based categories 
-      (No Risk, Level 1, Level 2, or Level 3) for the purpose of determining who is allowed 
-      to access the information and what security precautions must be taken to protect it 
-      against unauthorized access. It is the data and service owner’s responsibility to ensure 
-      appropriate security measures are taken depending on the risk classification. If you 
-      have any questions or need help, please reach out to the Information Security Group 
+      Brown has classified its information assets into one of four risk-based categories
+      (No Risk, Level 1, Level 2, or Level 3) for the purpose of determining who is allowed
+      to access the information and what security precautions must be taken to protect it
+      against unauthorized access. It is the data and service owner’s responsibility to ensure
+      appropriate security measures are taken depending on the risk classification. If you
+      have any questions or need help, please reach out to the Information Security Group
       (isg@brown.edu). [Brown Data Risk Classification](https://it.brown.edu/computing-policies/risk-classifications)
     affected_category: security
     answers:
       - answer: No Risk
-        category_classes: 
+        category_classes:
           - 0
           - 1
           - 2
@@ -466,7 +466,7 @@ questions:
         category_classes:
           - true
       - answer: No
-        category_classes: 
+        category_classes:
           - false
           - true
       - answer: Not sure
@@ -488,7 +488,7 @@ questions:
     information:
     affected_category: storage
     answers:
-      - answer: Less than 2 TB 
+      - answer: Less than 2 TB
         category_classes:
           - unlimited
           - 1 TB +
@@ -497,10 +497,10 @@ questions:
           - unlimited
           - 2 TB +
   - question: Do you expect to access from Oscar?
-    information: 
+    information:
     affected_category: access_from_oscar
     answers:
-      - answer: Yes 
+      - answer: Yes
         category_classes:
           - true
           - partial

--- a/services/visualization/index.yml
+++ b/services/visualization/index.yml
@@ -1,11 +1,11 @@
 title: Visualization
 description: |
     CCV has visualization experts working on cutting-edge 3D visualization for research.
-    We have, the Cave, a fully-immersive display system and work with a variety of devices, 
+    We have, the Cave, a fully-immersive display system and work with a variety of devices,
     like VR headsets and holographic displays.
 fa:
   prefix: fas
   icon: cubes
 links:
   - text: learn more about visualization at ccv
-    target: services/visualization
+    target: /services/visualization


### PR DESCRIPTION
the relative links were causing deeper buttons to look for things like `services/services/visualization` instead of `/services/visualization`