### PR TITLE
fix the broken fontawesome student icon

### DIFF
--- a/services/classroom/index.yml
+++ b/services/classroom/index.yml
@@ -4,7 +4,7 @@ description: |
   We can provide tutorials or give you access to cutting edge technology for teaching with code, such as JupyterHub.
 fa:
   prefix: fas
-  icon: users-class
+  icon: user-graduate
 links:
   - text: See all classroom services
     target: services/classroom


### PR DESCRIPTION
This is a baby PR to fix the broken icon on the `Classroom` card on our `Services` page.