### PR TITLE
update storage app table for gpfs oscar access

### DIFF
--- a/services/file-storage-and-transfer/index.yml
+++ b/services/file-storage-and-transfer/index.yml
@@ -348,9 +348,8 @@ services:
         notes:
           - except with Globus
       - name: access_from_oscar
-        class: partial
+        class: true
         notes:
-          - accessible on transfer nodes
       - name: security
         class: 2
         notes:


### PR DESCRIPTION
This is a baby PR to the storage app table. It just fixes the error that said gpfs had only "partial" availability from Oscar.