### PR TITLE
fix: remove former PI and toggle to inactive

### DIFF
--- a/our-work/collaborations/riddc.yml
+++ b/our-work/collaborations/riddc.yml
@@ -2,15 +2,13 @@ title: RI Data Discovery Center
 id: riddc
 description: "The goal of the RI Data Discovery Center is to become the national and international go-to-source for data about the Narragansett Bay ecosystem.
 CCV supports, maintains and upgrades existing infrastructure used by the RI Data Discovery Center at Brown University. This includes databases as well as code and web technology used to access and visualize historic and model data."
-active: True
+active: False
 department:
   - ecology
 tags:
   - data-management
   - software-engineering
 investigators:
-  - name: Jeff Morgan
-    link: https://vivo.brown.edu/display/jrmorgan
   - name: Baylor Fox-Kemper
     link: https://vivo.brown.edu/display/bfoxkemp
 people:


### PR DESCRIPTION
This updates the RIDDC collaboration page