### PR TITLE
ci: add support for merge_group in preview

### DIFF
--- a/.github/workflows/preview_on_pr.yml
+++ b/.github/workflows/preview_on_pr.yml
@@ -1,5 +1,7 @@
 name: preview-on-pr
-on: pull_request
+on:
+  - pull_request
+  - merge_group
 jobs:
   yaml-validation:
     strategy:


### PR DESCRIPTION
as described here: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

Todos once merged: add "require merge queue" in branch protection rules