### PR TITLE
fix: update from fy22 to fy24 in rates page

### DIFF
--- a/rates.md
+++ b/rates.md
@@ -7,7 +7,7 @@ tagDescription: Check rates for advanced research computing that require extra r
 date: 2020-08-05T18:04:51.000+00:00
 lead: We provide services with limited resources at no cost to all
   members affiliated with Brown. For advanced computing that requires extra resources,
-  we charge a quarterly fee. See below the rates for FY22.
+  we charge a quarterly fee. See below the rates for FY24.
 
 ---
 


### PR DESCRIPTION
This is a baby PR that updates the fiscal year specified in the rates page.