### PR TITLE
fix: image paths in camilos blog post

### DIFF
--- a/blog/vr-volume-viewer.md
+++ b/blog/vr-volume-viewer.md
@@ -18,17 +18,17 @@ CCV has worked in scientific visualization since its inception back in 2003, col
 It is our objective to do research on the best tools to implement these types of applications, going from open source libraries to free to use 3D visualization tools such as blender, paraview and Unity 3D. We also follow software engineering standards to ensure sustainable maintenance and produce efficient and effective products.
 Historically, we have worked in the OpenGL rendering pipeline to place these datasets into 3D scenes. This library has been fully optimized for triangle mesh indexing and rendering 3D content for interactive real time simulations. Most of the time the programmer only needs to focus on implementing tools to apply transformation to those triangles and facilitate the manipulation of objects by the user.
 
-![image1](/images/blog/vr-volume-viewer/image1.png)  3D Bunny mesh represented as a set of triangles
+![image1](/content/images/blog/vr-volume-viewer/image1.png)  3D Bunny mesh represented as a set of triangles
 
 ### Volumetric datasets
 However, some of our collaborators reached out to us looking to display 3D volumetric datasets such as medical images in DICOM format, density of gasses in a volumetric space and temperatures in the ocean. Rendering this type of data in 3D space is a challenge due to the type of algorithms needed to map scalar values to voxels (a voxel is the 3D version of a 2D pixel).
 
-![image2](/images/blog/vr-volume-viewer/image2.png)  3D cube represented as a set of voxels
+![image2](/content/images/blog/vr-volume-viewer/image2.png)  3D cube represented as a set of voxels
 
 ### Volumetric Ray Marching
 The most used algorithm is the ray marching technique. It consists of representing the data inside a unitary cube placed in the center of the scene (position x=0,y=0,z=0). After that, a ray is created from the camera to position in the direction of the cube location, and walk on the ray in small steps until it reaches the cube. At the ray-cube intersection point we can query the value from the data and move in the ray another step. If we find a different value, we can interpolate or take the maximum between the previously observed value and the new one. We continue moving in the same direction until we have traversed the cube. The accumulated value is converted into color space and passed to the fragment shader to paint  a colored-voxel on screen. As you can see, no triangles are needed to render this type of dataset. 
 
-![image3](/images/blog/vr-volume-viewer/image3.png) Graphic representation of ray marching algorithm
+![image3](/content/images/blog/vr-volume-viewer/image3.png) Graphic representation of ray marching algorithm
 
 ### Challenges and solutions
 Now we  have the knowledge on how to deal with volumes, but we still face a couple of issues:
@@ -46,12 +46,12 @@ After 2 months of research and implementation, we were able to come up with a vo
 ### The results
 The first prototype was able to load and render tiff stacks as volumes in grayscale. Most of our initial tests gave us a decent frame rate performance between 60-70 fps. In VR mode we were getting some jittering in the volume at the moment we rotated the camera, and some z-fighting depending on the point of view. Also, the application did not have enough interactivity with the user, only the camera movement (paneling, zoom). The data was being loaded using the command line arguments. The next iterations of the prototype included new features such as GUI on desktop mode and world space UI on VR mode, user interaction using VR controller (translate and rotate model), camera animation for multiple views and video exporting.
 
-| ![image4a](/images/blog/vr-volume-viewer/image4a.png) | ![image4b](/images/blog/vr-volume-viewer/img4b.png) |
+| ![image4a](/content/images/blog/vr-volume-viewer/image4a.png) | ![image4b](/content/images/blog/vr-volume-viewer/img4b.png) |
 |:-:|:-:|
 
 This is a demo of the temperature and salinity of the Rhode Island narragansett bay represented as volume data. Our tool is able to render mesh and volume data at the same time for a full 3D representation of the terrain plus the surrounding ocean. 
 
-![image5](/images/blog/vr-volume-viewer/image5.gif)
+![image5](/content/images/blog/vr-volume-viewer/image5.gif)
 
 ### Conclusion
 It is important to do research on the type of tools that could be used to easily visualize 3D data. However, it is vital to understand the rendering techniques and algorithms that those tools work with. Being able to implement ray marching helped our team to quickly develop a tool that adjusted to our own requirements and we can maintain following software engineer standards.


### PR DESCRIPTION
i added `/content` to the beginning of each image path so the blog images can be found within the `ccv-website-nuxt` repo. the images will not render within this repo, but this is what we need to do to get them to work as long as they are stored in this repo as a submodule within the`ccv-website-nuxt` repo. 