### PR TITLE
feat: highlight oscar links and bootcamp

### DIFF
--- a/our-work/workshops-and-talks/bootcamp-2024.yml
+++ b/our-work/workshops-and-talks/bootcamp-2024.yml
@@ -1,0 +1,21 @@
+title: CCV Bootcamp 2024
+description: A series of interactive online tutorials designed to introduce members of the Brown community to some of the research computing resources available to them. The tutorials will provide participants with the practical knowledge necessary to make effective use of Oscar, Brown's research computing cluster, in their own research, while introducing users to the range of research computing resources available at Brown.
+slug: bootcamp_2024
+languages:
+  - unix-cli
+  - bash
+  - python
+  - julia
+  - r
+  - matlab
+  - sql
+tags:
+  - oscar
+  - hpc
+  - visualization
+groups:
+  - bootcamp
+links:
+  - category: website
+    url: https://docs.ccv.brown.edu/bootcamp-2024
+

--- a/our-work/workshops-and-talks/bootcamp-2024.yml
+++ b/our-work/workshops-and-talks/bootcamp-2024.yml
@@ -21,7 +21,7 @@ people:
   - name: Prithvi Thakur
     github_user: thehalfspace
   - name: Ashok Ragavendran
-    gihub_user: ashokrags
+    github_user: ashokrags
   - name: Prasad Bandarkar
     github_user: prasadbandarkar
   - name: John Holland

--- a/our-work/workshops-and-talks/bootcamp-2024.yml
+++ b/our-work/workshops-and-talks/bootcamp-2024.yml
@@ -16,7 +16,38 @@ tags:
 people:
   - name: Paul Hall
     github_user: phall-brown
-
+  - name: Rain Fan
+    github_user: rainxfan
+  - name: Prithvi Thakur
+    github_user: thehalfspace
+  - name: Ashok Ragavendran
+    github_user: ashokrags
+  - name: Prasad Bandarkar
+    github_user: prasadbandarkar
+  - name: John Gerrard Holland
+    github_user: hollandjg
+  - name: Carlos Paniagua
+    github_user: cpaniaguam
+  - name: Ford McDonald
+    github_user: fordmcdonald
+  - name: Robert Gemma, Jr.
+    github_user: robertgemmajr
+  - name: Paul Cao
+    github_user: paulcao-brown
+  - name: Paul Stey
+    github_user: paulstey
+  - name: Ellen Duong
+    github_user: eldu
+  - name: George Dang
+    github_user: gtdang
+  - name: Eric Salomaki
+    github_user: ericsalomaki
+  - name: August Guang
+    github_user: aguang
+  - name: Jordan Lawson
+    github_user: j-stat
+  - name: Joselynn Wallace
+    github_user: jrwallace
 groups:
   - bootcamp
 links:

--- a/our-work/workshops-and-talks/bootcamp-2024.yml
+++ b/our-work/workshops-and-talks/bootcamp-2024.yml
@@ -13,6 +13,43 @@ tags:
   - oscar
   - hpc
   - visualization
+people:
+  - name: Paul Hall
+    github_user: phall-brown
+  - name: Rain Fan
+    github_user: rainxfan
+  - name: Prithvi Thakur
+    github_user: thehalfspace
+  - name: Ashok Ragavendran
+    gihub_user: ashokrags
+  - name: Prasad Bandarkar
+    github_user: prasadbandarkar
+  - name: John Holland
+    github_user: hollandjg
+  - name: Carlos Paniagua
+    github_user: cpaniaguam
+  - name: Ford McDonald
+    github_user: fordmcdonald
+  - name: Jason Radford
+    github_user: jsradford
+  - name: Robert Gemma Jr.
+    github_user: robertgemmajr
+  - name: Paul Cao
+    github_user: paulcao-brown
+  - name: Paul Stey
+    github_user: paulstey
+  - name: Ellen Duong
+    github_user: eldu
+  - name: George Dang
+    github_user: gtdang
+  - name: Eric Salomaki
+    github_user: ericsalomaki
+  - name: August Guang
+    github_user: aguang
+  - name: Jordan Lawson
+    github_user: j-stat
+  - name: Joselynn Wallace
+    github_user: jrwallace
 groups:
   - bootcamp
 links:

--- a/our-work/workshops-and-talks/bootcamp-2024.yml
+++ b/our-work/workshops-and-talks/bootcamp-2024.yml
@@ -30,8 +30,6 @@ people:
     github_user: cpaniaguam
   - name: Ford McDonald
     github_user: fordmcdonald
-  - name: Jason Radford
-    github_user: jsradford
   - name: Robert Gemma Jr.
     github_user: robertgemmajr
   - name: Paul Cao

--- a/our-work/workshops-and-talks/bootcamp-2024.yml
+++ b/our-work/workshops-and-talks/bootcamp-2024.yml
@@ -16,38 +16,7 @@ tags:
 people:
   - name: Paul Hall
     github_user: phall-brown
-  - name: Rain Fan
-    github_user: rainxfan
-  - name: Prithvi Thakur
-    github_user: thehalfspace
-  - name: Ashok Ragavendran
-    github_user: ashokrags
-  - name: Prasad Bandarkar
-    github_user: prasadbandarkar
-  - name: John Holland
-    github_user: hollandjg
-  - name: Carlos Paniagua
-    github_user: cpaniaguam
-  - name: Ford McDonald
-    github_user: fordmcdonald
-  - name: Robert Gemma Jr.
-    github_user: robertgemmajr
-  - name: Paul Cao
-    github_user: paulcao-brown
-  - name: Paul Stey
-    github_user: paulstey
-  - name: Ellen Duong
-    github_user: eldu
-  - name: George Dang
-    github_user: gtdang
-  - name: Eric Salomaki
-    github_user: ericsalomaki
-  - name: August Guang
-    github_user: aguang
-  - name: Jordan Lawson
-    github_user: j-stat
-  - name: Joselynn Wallace
-    github_user: jrwallace
+
 groups:
   - bootcamp
 links:

--- a/our-work/workshops-and-talks/bootcamp-2024.yml
+++ b/our-work/workshops-and-talks/bootcamp-2024.yml
@@ -6,7 +6,7 @@ languages:
   - bash
   - python
   - julia
-  - r
+  - R
   - matlab
   - sql
 tags:

--- a/our-work/workshops-and-talks/gcp_intro.yml
+++ b/our-work/workshops-and-talks/gcp_intro.yml
@@ -17,6 +17,6 @@ links:
   - category: code
     url: https://github.com/dscov-tutorials/gcp-intro
   - category: slides 
-    url: http://bit.ly/dscov-gcp
+    url: https://brownccv.notion.site/Introduction-to-Google-Cloud-023dc53073504132b76bb487cebfe86a
   - category: video
     url: https://brown.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=aa0aa1a2-acee-4878-b366-ab9f003367bd


### PR DESCRIPTION
Adds a card under https://ccv.brown.edu/our-work/workshops-and-talks for the 2024 bootcamp