### PR TITLE
refactor: matrix

### DIFF
--- a/storage-tool.yml
+++ b/storage-tool.yml
@@ -45,8 +45,6 @@ services:
           - up to 30 days
       - name: canvas_integration
         class: False
-      - name: secondary_site_backup
-        class: False
       - name: brown_network_required
         class: False
       - name: access_from_oscar
@@ -96,8 +94,6 @@ services:
         notes:
           - up to 6 months
       - name: canvas_integration
-        class: False
-      - name: secondary_site_backup
         class: False
       - name: brown_network_required
         class: True
@@ -155,8 +151,6 @@ services:
           - up to 6 months
       - name: canvas_integration
         class: False
-      - name: secondary_site_backup
-        class: True
       - name: brown_network_required
         class: True
         notes:
@@ -216,8 +210,6 @@ services:
           - up to 60 days
       - name: canvas_integration
         class: False
-      - name: secondary_site_backup
-        class: True
       - name: brown_network_required
         class: True
         notes:
@@ -266,8 +258,6 @@ services:
           - up to 60 days
       - name: canvas_integration
         class: True
-      - name: secondary_site_backup
-        class: True
       - name: brown_network_required
         class: True
         notes:
@@ -315,8 +305,6 @@ services:
           - up to 30 days
       - name: canvas_integration
         class: False
-      - name: secondary_site_backup
-        class: True
       - name: brown_network_required
         class: True
         notes:
@@ -361,8 +349,6 @@ services:
           - up to 6 weeks
       - name: canvas_integration
         class: False
-      - name: secondary_site_backup
-        class: True
       - name: brown_network_required
         class: True
         notes:
@@ -408,8 +394,6 @@ services:
         class: False
       - name: canvas_integration
         class: False
-      - name: secondary_site_backup
-        class: True
       - name: brown_network_required
         class: True
       - name: access_from_oscar

--- a/storage-tool.yml
+++ b/storage-tool.yml
@@ -43,6 +43,8 @@ services:
         class: True
         notes:
           - up to 30 days
+      - name: data_protection_replication
+        class: True
       - name: canvas_integration
         class: False
       - name: brown_network_required
@@ -93,6 +95,8 @@ services:
         class: True
         notes:
           - up to 6 months
+      - name: data_protection_replication
+        class: False
       - name: canvas_integration
         class: False
       - name: brown_network_required
@@ -149,6 +153,8 @@ services:
         class: True
         notes:
           - up to 6 months
+      - name: data_protection_replication
+        class: True
       - name: canvas_integration
         class: False
       - name: brown_network_required
@@ -208,6 +214,8 @@ services:
         class: True
         notes:
           - up to 60 days
+      - name: data_protection_replication
+        class: True
       - name: canvas_integration
         class: False
       - name: brown_network_required
@@ -256,6 +264,8 @@ services:
         class: True
         notes:
           - up to 60 days
+      - name: data_protection_replication
+        class: True
       - name: canvas_integration
         class: True
       - name: brown_network_required
@@ -303,6 +313,8 @@ services:
         class: True
         notes:
           - up to 30 days
+      - name: data_protection_replication
+        class: True
       - name: canvas_integration
         class: False
       - name: brown_network_required
@@ -347,6 +359,8 @@ services:
         class: True
         notes:
           - up to 6 weeks
+      - name: data_protection_replication
+        class: True
       - name: canvas_integration
         class: False
       - name: brown_network_required
@@ -392,6 +406,8 @@ services:
         class: False
       - name: data_protection_snapshots
         class: False
+      - name: data_protection_replication
+        class: True
       - name: canvas_integration
         class: False
       - name: brown_network_required

--- a/storage-tool.yml
+++ b/storage-tool.yml
@@ -43,8 +43,6 @@ services:
         class: True
         notes:
           - up to 30 days
-      - name: data_protection_replication
-        class: True
       - name: canvas_integration
         class: False
       - name: secondary_site_backup
@@ -97,8 +95,6 @@ services:
         class: True
         notes:
           - up to 6 months
-      - name: data_protection_replication
-        class: False
       - name: canvas_integration
         class: False
       - name: secondary_site_backup
@@ -157,8 +153,6 @@ services:
         class: True
         notes:
           - up to 6 months
-      - name: data_protection_replication
-        class: True
       - name: canvas_integration
         class: False
       - name: secondary_site_backup
@@ -220,8 +214,6 @@ services:
         class: True
         notes:
           - up to 60 days
-      - name: data_protection_replication
-        class: True
       - name: canvas_integration
         class: False
       - name: secondary_site_backup
@@ -272,8 +264,6 @@ services:
         class: True
         notes:
           - up to 60 days
-      - name: data_protection_replication
-        class: True
       - name: canvas_integration
         class: True
       - name: secondary_site_backup
@@ -323,8 +313,6 @@ services:
         class: True
         notes:
           - up to 30 days
-      - name: data_protection_replication
-        class: True
       - name: canvas_integration
         class: False
       - name: secondary_site_backup
@@ -371,8 +359,6 @@ services:
         class: True
         notes:
           - up to 6 weeks
-      - name: data_protection_replication
-        class: True
       - name: canvas_integration
         class: False
       - name: secondary_site_backup
@@ -420,8 +406,6 @@ services:
         class: False
       - name: data_protection_snapshots
         class: False
-      - name: data_protection_replication
-        class: True
       - name: canvas_integration
         class: False
       - name: secondary_site_backup


### PR DESCRIPTION
> Remove redundant fields in the matrix. ‘Data Protection Replication’ and ’secondary site backup’.

Navigate to the storage page and then the comparison